### PR TITLE
feat: Add `@deprecated` annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ _Output_: [examples/readme-example.md](examples/readme-example.md)<br/><br/>
 #
 # @requires foo
 # @requires bar
+# @deprecated use yell-hello instead
 #
 # @see validate()
 # @see [shdoc](https://github.com/reconquest/shdoc).
@@ -104,6 +105,10 @@ deeper-level() { echo; }
 
 # @description Back up again
 up-again() { echo; }
+
+# @description A deprecated function
+# @deprecated Because it's old
+deprecated-function() { echo; }
 ~~~
 
 </td>
@@ -128,8 +133,11 @@ The project solves lots of problems:
 * [Sub-section](#sub-section)
   * [deeper-level](#deeper-level)
 * [up-again](#up-again)
+* [deprecated-function](#deprecated-function)
 
 ## say-hello
+
+**DEPRECATED** Use yell-hello instead
 
 My super function.
 Not thread-safe.
@@ -199,6 +207,11 @@ This is nested
 
 Back up again
 
+## deprecated-function
+
+**DEPRECATED** Because it's old
+
+A deprecated function
 ~~~
 
 </td>
@@ -254,6 +267,19 @@ A multiline description of the project/section/function.
 # @description My super function.
 # Second line of my super function description.
 function super() {
+    ...
+}
+```
+
+### `@deprecated`
+
+Whether or not the function is deprecated. If it is, a short deprecation notice
+will be prepended to the description.
+
+**Example**
+```bash
+# @deprecated
+say-hello() {
     ...
 }
 ```
@@ -388,6 +414,19 @@ Can be specified multiple times to describe any number of variables.
 # @description Sets hello to the variable REPLY
 # @set REPLY string Greeting message.
 set-hello() {
+    ...
+}
+```
+
+### `@deprecated`
+
+Indicates that the function is deprecated
+
+**Example**
+
+```bash
+# @deprecated use yell-hello-world instead
+say-hello-world() {
     ...
 }
 ```

--- a/examples/readme-example.md
+++ b/examples/readme-example.md
@@ -21,6 +21,7 @@ The project solves lots of problems:
 * [Sub-section](#sub-section)
   * [deeper-level](#deeper-level)
 * [up-again](#up-again)
+* [deprecated-function](#deprecated-function)
 
 ## say-hello
 
@@ -62,16 +63,16 @@ echo "test: $(say-hello World)"
 * Output 'Oups !' on error.
   It did it again.
 
-### See also
-
-* [validate()](#validate)
-* [shdoc](https://github.com/reconquest/shdoc).
-
 ### Requires
 
 * Some very specific requirements
   that continue on the next line (indent by a
   single space to continue)
+
+### See also
+
+* [validate()](#validate)
+* [shdoc](https://github.com/reconquest/shdoc).
 
 ## Sub-section
 
@@ -97,4 +98,10 @@ This is nested
 ## up-again
 
 Back up again
+
+## deprecated-function
+
+**DEPRECATED** Because it's old
+
+A deprecated function
 

--- a/examples/readme-example.sh
+++ b/examples/readme-example.sh
@@ -60,3 +60,7 @@ deeper-level() { echo; }
 
 # @description Back up again
 up-again() { echo; }
+
+# @description A deprecated function
+# @deprecated Because it's old
+deprecated-function() { echo; }

--- a/shdoc
+++ b/shdoc
@@ -537,7 +537,7 @@ function render_docblock(func_name, description, docblock, nesting) {
     if (deprecated) {
         debug("→ DEPRECATED")
 
-        deprecatedText = "**DEPRECATED**"
+        deprecatedText = render("strong", "DEPRECATED")
         push(lines, deprecatedText " " deprecated)
         push(lines, "")
     }

--- a/shdoc
+++ b/shdoc
@@ -733,11 +733,12 @@ function debug(msg) {
 
     handle_description()
 
+    sub(/@description/, "")
     reset()
 }
 
 in_description {
-    if (/^[^[[:space:]]*#]|^[[:space:]]*# @[a-z]+|^[[:space:]]*[^#]|^[[:space:]]*$/ && !match($0, /@description/)) {
+    if (/^[^[[:space:]]*#]|^[[:space:]]*# @[a-z]+|^[[:space:]]*[^#]|^[[:space:]]*$/) {
         debug("→ → in_description: leave")
 
         in_description = 0
@@ -749,7 +750,6 @@ in_description {
         description = concat(description, $0)
         next
     } else {
-        sub(/^[[:space:]]*# @description[[:space:]]*/, "")
         sub(/^[[:space:]]*#[[:space:]]*/, "")
         sub(/^[[:space:]]*#$/, "")
         debug("→ → in_description: concat [" $0 "]")

--- a/shdoc
+++ b/shdoc
@@ -534,6 +534,14 @@ function render_docblock(func_name, description, docblock, nesting) {
       lines[0] = render(nesting_top, func_name)
     }
 
+    if (deprecated) {
+        debug("→ DEPRECATED")
+
+        deprecatedText = "**DEPRECATED**"
+        push(lines, deprecatedText " " deprecated)
+        push(lines, "")
+    }
+
     if (description != "") {
         push(lines, description)
         # Add empty line to signal end of description.
@@ -729,7 +737,7 @@ function debug(msg) {
 }
 
 in_description {
-    if (/^[^[[:space:]]*#]|^[[:space:]]*# @[^d]|^[[:space:]]*[^#]|^[[:space:]]*$/) {
+    if (/^[^[[:space:]]*#]|^[[:space:]]*# @[a-z]+|^[[:space:]]*[^#]|^[[:space:]]*$/ && !match($0, /@description/)) {
         debug("→ → in_description: leave")
 
         in_description = 0
@@ -888,6 +896,15 @@ in_example {
     sub(/[[:space:]]*# @see /, "")
 
     docblock_push("see", $0)
+
+    next
+}
+
+/^[[:space:]]*# @deprecated/ {
+    debug("→ @deprecated")
+    sub(/[[:space:]]*# @deprecated /, "")
+
+    deprecated = $0
 
     next
 }

--- a/tests/testcases/@deprecated.test.sh
+++ b/tests/testcases/@deprecated.test.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+tests:put input <<EOF
+# @description FUNCTION DESCRIPTION
+#
+# @deprecated this one is ignored
+# @deprecated REASON
+#  ignored line
+func() {
+
+EOF
+
+tests:put expected <<EOF
+## Index
+
+* [func](#func)
+
+## func
+
+**DEPRECATED** REASON
+
+FUNCTION DESCRIPTION
+EOF
+
+assert


### PR DESCRIPTION
Add a `@deprecated` tag (original patch written by @hyperupcall) to functions that renders like this:

```bash
# @description A deprecated function
# @deprecated Because it's old
deprecated-function() { echo; }
```

## deprecated-function

**DEPRECATED** Because it's old

A deprecated function
