### PR TITLE
Add support for subshell functions

### DIFF
--- a/shdoc
+++ b/shdoc
@@ -939,7 +939,7 @@ match($0, /^([[:blank:]]*#[[:blank:]]+)@(stdin|stdout|stderr)[[:blank:]]+(.*[^[:
 # - `function function_name () {`
 # - `function_name () {`
 # - `function_name {`
-/^[[:blank:]]*(function[[:blank:]]+)?([a-zA-Z0-9_\-:-\\.]+)[[:blank:]]*(\([[:blank:]]*\))?[[:blank:]]*\{*/ \
+/^[[:blank:]]*(function[[:blank:]]+)?([a-zA-Z0-9_\-:-\\.]+)[[:blank:]]*(\([[:blank:]]*\))?[[:blank:]]*[({]/ \
 {
     process_function($0)
     function_declaration_complete = 1
@@ -955,7 +955,7 @@ match($0, /^([[:blank:]]*#[[:blank:]]+)@(stdin|stdout|stderr)[[:blank:]]+(.*[^[:
 }
 
 # Handle lone opening bracket if previous line is a function declaration.
-/^[[:blank:]]*\{/ \
+/^[[:blank:]]*[({]/ \
     && function_declaration != "" {
     debug("→ multi-line function declaration.")
     # Process function declaration.

--- a/tests/testcases/@function-declaration.test.sh
+++ b/tests/testcases/@function-declaration.test.sh
@@ -35,6 +35,35 @@ function g
 function h()
 { echo "h"; }
 
+# @description Subshell Function n°1
+sa() (
+    echo "a"
+)
+
+# @description Subshell Function n°2
+sb() ( echo "b" ; )
+
+# @description Subshell Function n°3
+:sc() ( echo "c"; )
+
+# @description Subshell Function n°4
+sd-method()
+( echo "d"; )
+
+# @description Subshell Function n°5
+function se:function ( echo "e"; )
+
+# @description Subshell Function n°6
+function sf() ( echo "f"; )
+
+# @description Subshell Function n°7
+function sg
+( echo "g"; )
+
+# @description Subshell Function n°8
+function sh()
+( echo "h"; )
+
 a
 b
 :c
@@ -43,6 +72,15 @@ e:function
 f
 g
 h
+
+sa
+sb
+:sc
+sd-method
+se:function
+sf
+sg
+sh
 EOF
 
 tests:put expected <<EOF
@@ -65,6 +103,14 @@ with some more lines
 * [f](#f)
 * [g](#g)
 * [h](#h)
+* [sa](#sa)
+* [sb](#sb)
+* [:sc](#sc)
+* [sd-method](#sd-method)
+* [se:function](#sefunction)
+* [sf](#sf)
+* [sg](#sg)
+* [sh](#sh)
 
 ## a
 
@@ -98,6 +144,37 @@ Function n°7
 
 Function n°8
 
+## sa
+
+Subshell Function n°1
+
+## sb
+
+Subshell Function n°2
+
+## :sc
+
+Subshell Function n°3
+
+## sd-method
+
+Subshell Function n°4
+
+## se:function
+
+Subshell Function n°5
+
+## sf
+
+Subshell Function n°6
+
+## sg
+
+Subshell Function n°7
+
+## sh
+
+Subshell Function n°8
 EOF
 
 assert


### PR DESCRIPTION
Functions in the form `func () ( ... )` are documented just like the more common `{}` version.