### PR TITLE
Feature: Normalize spaces

### DIFF
--- a/shdoc
+++ b/shdoc
@@ -683,7 +683,7 @@ function debug(msg) {
     sub(/^[[:space:]]+#/, "#")
 }
 
-match($0, /^#([[:space:]][[:space:]]+)@.*/, trimmed_spaces) {
+match($0, /^#([[:space:]]+)@.*/, trimmed_spaces) {
     debug("→ normalize space between '#' and '@'")
     multiline_min_indent = trimmed_spaces[1]
     debug("→ → keep [" $multiline_min_indent "] for multiline indent handling")

--- a/shdoc
+++ b/shdoc
@@ -679,6 +679,14 @@ function debug(msg) {
 
 {
     debug("line: [" $0 "]")
+    # strip any leading spaces
+    sub(/^[[:space:]]+#/, "#")
+}
+
+/^#[[:space:]][[:space:]]+@.*/ {
+    debug("→ normalize space between '#' and '@'")
+    sub(/^#[[:space:]]+@/, "# @")
+    debug("→ → result line: [" $0 "]")
 }
 
 /^[[:space:]]*#.*?%%[a-zA-Z0-9_\-]+%%.*/ {

--- a/shdoc
+++ b/shdoc
@@ -683,8 +683,10 @@ function debug(msg) {
     sub(/^[[:space:]]+#/, "#")
 }
 
-/^#[[:space:]][[:space:]]+@.*/ {
+match($0, /^#([[:space:]][[:space:]]+)@.*/, trimmed_spaces) {
     debug("→ normalize space between '#' and '@'")
+    multiline_min_indent = trimmed_spaces[1]
+    debug("→ → keep [" $multiline_min_indent "] for multiline indent handling")
     sub(/^#[[:space:]]+@/, "# @")
     debug("→ → result line: [" $0 "]")
 }
@@ -946,9 +948,8 @@ multiple_line_docblock_name {
 # Allow for multiple lines entries.
 match($0, /^# @(stdin|stdout|stderr|requires)[[:blank:]]+(.*[^[:blank:]])[[:blank:]]*$/, contents) {
     # Fetch matched values.
-    indentation = contents[1]
-    docblock_name = contents[2]
-    text = contents[3]
+    docblock_name = contents[1]
+    text = contents[2]
 
     debug("→ @" docblock_name)
 
@@ -957,7 +958,9 @@ match($0, /^# @(stdin|stdout|stderr|requires)[[:blank:]]+(.*[^[:blank:]])[[:blan
 
     # Signal the start of a multiple line section.
     multiple_line_docblock_name = docblock_name
-    multiple_line_identation_regex = "^" indentation "[[:blank:]]+[^[:blank:]].*$"
+    # since lines are normalized to start with '#' or '# @', indentation of multilines must happen AFTER
+    # the comment starting '#' and be 
+    multiple_line_identation_regex = "#" multiline_min_indent "[[:blank:]]+[^[:blank:]].*$"
 
     # Stop processing current line, and process next line.
     next

--- a/shdoc
+++ b/shdoc
@@ -689,7 +689,7 @@ function debug(msg) {
     debug("→ → result line: [" $0 "]")
 }
 
-/^[[:space:]]*#.*?%%[a-zA-Z0-9_\-]+%%.*/ {
+/^#.*?%%[a-zA-Z0-9_\-]+%%.*/ {
     debug("→ found placeholders")
     splitted[0] = ""
     patsplit($0, splitted, /%%([a-zA-Z0-9_\-]+?)%%/)
@@ -704,7 +704,7 @@ function debug(msg) {
     }
 }
 
-/^[[:space:]]*# @internal/ {
+/^# @internal/ {
     debug("→ @internal")
     # ignore the flag while we are in an internal section
     # to prevent dangling values not reset by function blocks
@@ -716,9 +716,9 @@ function debug(msg) {
     next
 }
 
-/^[[:space:]]*# @(name|file)/ {
+/^# @(name|file)/ {
     debug("→ @name|@file")
-    sub(/^[[:space:]]*# @(name|file)[[:space:]]*/, "")
+    sub(/^# @(name|file)[[:space:]]*/, "")
     file_intro_enabled = 1
     file_title = $0
     in_file_block = 1
@@ -726,15 +726,15 @@ function debug(msg) {
     next
 }
 
-/^[[:space:]]*# @brief/ {
+/^# @brief/ {
     debug("→ @brief")
-    sub(/^[[:space:]]*# @brief /, "")
+    sub(/^# @brief /, "")
     file_brief = $0
 
     next
 }
 
-/^[[:space:]]*# @description/ {
+/^# @description/ {
     debug("→ @description")
     in_description = 1
     in_example = 0
@@ -746,27 +746,27 @@ function debug(msg) {
 }
 
 in_description {
-    if (/^[^[[:space:]]*#]|^[[:space:]]*# @[a-z]+|^[[:space:]]*[^#]|^[[:space:]]*$/) {
+    if (/^[^#]|^# @[a-z]+|^[[:space:]]*[^#]|^[[:space:]]*$/) {
         debug("→ → in_description: leave")
 
         in_description = 0
 
         handle_description()
-    } else if (match($0, /^[[:space:]]*#\|/)) {
+    } else if (match($0, /^#\|/)) {
         debug("→ → in_description: literal [" $0 "] (keep spaces)")
-        sub(/^[[:space:]]*#\|/, "")
+        sub(/^#\|/, "")
         description = concat(description, $0)
         next
     } else {
-        sub(/^[[:space:]]*#[[:space:]]*/, "")
-        sub(/^[[:space:]]*#$/, "")
+        sub(/^#[[:space:]]*/, "")
+        sub(/^#$/, "")
         debug("→ → in_description: concat [" $0 "]")
         description = concat(description, $0)
         next
     }
 }
 
-/^[[:space:]]*# @endsection/ {
+/^# @endsection/ {
   debug("→ @endsection")
   process_section()
   section = ""
@@ -778,9 +778,9 @@ in_description {
   next
 }
 
-/^[[:space:]]*# @section/ {
+/^# @section/ {
   debug("→ @section")
-  sub(/^[[:space:]]*# @section /, "")
+  sub(/^# @section /, "")
   if (internal_section){
       internal_section = 0
   }
@@ -791,7 +791,7 @@ in_description {
   next
 }
 
-/^[[:space:]]*# @example/ {
+/^# @example/ {
     debug("→ @example")
     in_example = 1
 
@@ -799,12 +799,12 @@ in_description {
 }
 
 in_example {
-    if (! /^[[:space:]]*#[ ]{1,}/) {
+    if (! /^#[ ]{1,}/) {
         debug("→ → in_example: leave")
         in_example = 0
     } else {
         debug("→ → in_example: concat")
-        sub(/^[[:space:]]*#/, "")
+        sub(/^#/, "")
 
         docblock_concat("example", $0)
         next
@@ -872,8 +872,8 @@ in_example {
     next
 }
 
-# Select @noargs line with no additionnal text.
-/^[[:space:]]*#[[:blank:]]+@noargs[[:blank:]]*$/ {
+# Select @noargs line with no additional text.
+/^# @noargs[[:blank:]]*$/ {
     debug("→ @noargs")
     docblock["noargs"] = 1
 
@@ -881,25 +881,25 @@ in_example {
     next
 }
 
-/^[[:space:]]*# @set/ {
+/^# @set/ {
     debug("→ @set")
-    sub(/^[[:space:]]*# @set /, "")
+    sub(/^# @set /, "")
 
     docblock_push("set", $0)
 
     next
 }
 
-/^[[:space:]]*# @exitcode/ {
+/^# @exitcode/ {
     debug("→ @exitcode")
-    sub(/^[[:space:]]*# @exitcode /, "")
+    sub(/^# @exitcode /, "")
 
     docblock_push("exitcode", $0)
 
     next
 }
 
-/^[[:space:]]*# @see/ {
+/^# @see/ {
     debug("→ @see")
     sub(/[[:space:]]*# @see /, "")
 
@@ -908,7 +908,7 @@ in_example {
     next
 }
 
-/^[[:space:]]*# @deprecated/ {
+/^# @deprecated/ {
     debug("→ @deprecated")
     sub(/[[:space:]]*# @deprecated /, "")
 
@@ -928,7 +928,7 @@ multiple_line_docblock_name {
         # Current line has the same indentation as the stderr section.
     
         # Remove indentation and trailing spaces.
-        sub(/^[[:space:]]*#[[:space:]]+/, "")
+        sub(/^#[[:space:]]+/, "")
         sub(/[[:space:]]+$/, "")
 
         # Push matched message to corresponding docblock.
@@ -944,7 +944,7 @@ multiple_line_docblock_name {
 
 # Process similarly @stdin, @stdout, @stderr and @requires entries.
 # Allow for multiple lines entries.
-match($0, /^([[:blank:]]*#[[:blank:]]+)@(stdin|stdout|stderr|requires)[[:blank:]]+(.*[^[:blank:]])[[:blank:]]*$/, contents) {
+match($0, /^# @(stdin|stdout|stderr|requires)[[:blank:]]+(.*[^[:blank:]])[[:blank:]]*$/, contents) {
     # Fetch matched values.
     indentation = contents[1]
     docblock_name = contents[2]


### PR DESCRIPTION
This PR changes how spaces are handled to simply all the matching rules and thus reduce code clutter.

- any space **before** `#` is now stripped
- spaces between `#` and `@` will be normalized to exactly one space
- Since multiline annotations depend on indentation level, the blank text AFTER `#` up to (and not including) the first none-space character is 'saved' for pattern matching when a multiline annotion is encountered.

The last normalization step will break current behaviour for multiline annotations in one special case:

```sh
# @description With multiline
# NOTE: Spaces BEFORE '#' are discarded long before annotations are evaluated.
     #    @requires This is a working case
     #     'count' of blanks starts at the same column and second line is at least one space deeper
   #    @requires Correctly ignored
   #    Same start column, but no deeper nesting
 #    @requires Incorrectly ignored
   #    The block is indendented optically, but the 'distance' to the starting '#' is identical (4)
   #    Thus it is not considered to be indented
someFunc() {
  #...
}
```

I think keeping '#' aligned would help reability much more than allowing to place it literally anywhere. It's not too hard to keep it consistent for one block at least. As such, i'm not going to add the complexity to deal with this.

closes: #11 